### PR TITLE
feat: add typewriter effect to header and include CSS for animation

### DIFF
--- a/src/app/typewriter.css
+++ b/src/app/typewriter.css
@@ -1,0 +1,74 @@
+@keyframes writer {
+  0% {
+    content: 'J';
+  }
+  7% {
+    content: 'Ja';
+  }
+  14% {
+    content: 'Jac';
+  }
+  21% {
+    content: 'Jaco';
+  }
+  28% {
+    content: 'Jacob';
+  }
+  35% {
+    content: 'Jacob ';
+  }
+  42% {
+    content: 'Jacob S';
+  }
+  49% {
+    content: 'Jacob Sa';
+  }
+  56% {
+    content: 'Jacob Sal';
+  }
+  63% {
+    content: 'Jacob Sala';
+  }
+  70% {
+    content: 'Jacob Salaz';
+  }
+  77% {
+    content: 'Jacob Salaza';
+  }
+  84% {
+    content: 'Jacob Salazak';
+  }
+  91% {
+    content: 'Jacob Salazaku';
+  }
+  100% {
+    content: 'Jacob Salazaku';
+  }
+}
+
+#typewriter::before {
+  content: '';
+  animation:
+    writer 4s steps(14) forwards,
+    pause 10s linear 4s;
+  animation-delay: 10s;
+}
+
+@keyframes blink {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+#typewriter::after {
+  content: '_';
+  animation: blink 0.4s alternate 0.3;
+  animation-iteration-count: infinite;
+}
+
+#typewriter {
+  font-family: 'Courier New', Courier, monospace;
+}

--- a/src/components/header-banner.tsx
+++ b/src/components/header-banner.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import { getTranslations } from 'next-intl/server';
+import '../app/typewriter.css';
 import { Link } from './Link/link';
 
 const Header = async () => {
@@ -9,9 +10,10 @@ const Header = async () => {
     <section className="mt-4 flex w-full flex-col items-center lg:max-w-screen-lg">
       <div className="flex w-full flex-col items-center pb-4 lg:flex-row lg:justify-between">
         <div className="flex w-full flex-col items-center justify-center gap-4 px-2 lg:h-[500px] lg:items-start lg:gap-8">
-          <h1 className="text-4xl font-light text-beige-1 lg:text-6xl">
-            Jacob Salazaku
-          </h1>
+          <h1
+            id="typewriter"
+            className="text-4xl font-light text-beige-1 lg:text-6xl"
+          ></h1>
           <h2 className="text-2xl font-light text-white lg:text-3xl">
             {t('position')}
           </h2>


### PR DESCRIPTION
This pull request introduces a typewriter animation effect to the header banner and updates the corresponding CSS and component files to support this new feature.

### Animation and Style Changes:

* Added a typewriter animation keyframes to `src/app/typewriter.css` to animate the text "Jacob Salazaku" letter by letter.
* Included the `typewriter.css` file in `src/components/header-banner.tsx` to apply the new styles.

### Component Update:

* Updated the `Header` component in `src/components/header-banner.tsx` to replace the static header text with an animated typewriter effect by adding an element with the `id="typewriter"`.