### PR TITLE
adjust typewriter iteration and delete delay on it

### DIFF
--- a/src/app/typewriter.css
+++ b/src/app/typewriter.css
@@ -51,7 +51,6 @@
   animation:
     writer 4s steps(14) forwards,
     pause 10s linear 4s;
-  animation-delay: 10s;
 }
 
 @keyframes blink {


### PR DESCRIPTION
This pull request includes a small change to the `src/app/typewriter.css` file. The change removes the `animation-delay` property from the CSS animation.